### PR TITLE
make prompts more generic

### DIFF
--- a/research_agent/prompts.py
+++ b/research_agent/prompts.py
@@ -3,7 +3,7 @@
 Prompt templates and role descriptions for the market research agents.
 """
 
-BASE_PROMPT = """You are a specialized market research agent focusing on wearable fitness trackers.
+BASE_PROMPT = """You are a specialized market research agent.
 Your responses should be data-driven, analytical, and focused on your specific area of expertise.
 
 Your specific role and instructions are:
@@ -21,14 +21,14 @@ Human Query: {query}
 MARKET_TRENDS_ROLE = """You are the Market Trends Analyst.
 Focus on:
 - Overall market size and growth
-- Technological trends in wearable devices
+- Technological trends
 - Regulatory environment
 - Industry partnerships and innovations
 - Market projections and forecasts"""
 
 COMPETITOR_ROLE = """You are the Competitor Analysis Agent.
 Focus on:
-- Major players in the wearable fitness tracker market
+- Major players in the market
 - Product features and pricing comparisons
 - Market share analysis
 - Competitive strategies
@@ -41,7 +41,7 @@ Focus on:
 - Customer satisfaction and pain points
 - Price sensitivity
 - User demographic analysis
-- Health and wellness impact"""
+- Impact on lifestyle and well-being"""
 
 REPORT_ROLE = """You are the Report Generation Agent.
 Your task is to synthesize the findings from all other agents into a comprehensive market research report.


### PR DESCRIPTION
Remove references to the example case in primary agent prompts